### PR TITLE
Don't enforce production env. to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,19 @@ Heroku Buildpack for node/bower/gulp
 
 Usage
 -----
-1. Set your Heroku app's buildpack URL: `heroku config:set BUILDPACK_URL=https://github.com/krry/heroku-buildpack-nodejs-gulp-bower.git`
-2. Run `heroku config:set NODE_ENV=production` to set your environment to `production`
-3. Add a Gulp task called `heroku:production` that builds your app for production purposes
+- Set your Heroku app's buildpack URL: 
+```
+heroku config:set BUILDPACK_URL=https://github.com/artmees/heroku-buildpack-nodejs-gulp-bower.git`
+```
+- Run `heroku config:set NODE_ENV={{env}}` to set your environment to the desired environment. 
+  ex `production` or `staging`
+
+-  Add a Gulp task called for each enviroment you support `heroku:{{env}}` that builds your app.
+  ex `heroku:production` or `heroku:staging`
 
 Credits
 -------
 * Forked from [heroku-buildpack-nodejs](https://github.com/heroku/heroku-buildpack-nodejs).
+* Forked from [krry](https://github.com/krry/heroku-buildpack-nodejs-gulp-bower) awesome build back.
 * Incorporated bower check and install from [heroku-buildpack-nodejs-gulp-bower](https://github.com/davidmfoley/heroku-buildpack-nodejs-gulp-bower)
 * Heavily based on [heroku-buildpack-nodejs-grunt](https://github.com/mbuchetics/heroku-buildpack-nodejs-grunt).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ heroku config:set BUILDPACK_URL=https://github.com/artmees/heroku-buildpack-node
 - Run `heroku config:set NODE_ENV={{env}}` to set your environment to the desired environment. 
   ex `production` or `staging`
 
--  Add a Gulp task called for each enviroment you support `heroku:{{env}}` that builds your app.
-  ex `heroku:production` or `heroku:staging`
+- Run `heroku config:set NPM_CONFIG_PRODUCTION=false` as mentioned in [docs](https://devcenter.heroku.com/articles/nodejs-support#customizing-the-build-process) to allow heroku to install  `devDependencies` as well as `dependencies`
+
+-  Add a Gulp tasks called for each enviroment you support `heroku:{{env}}` that builds your app.
+  ex `heroku:production` and `heroku:staging` if `NODE_ENV` is set to `production` and `staging` respectively.
+
 
 Credits
 -------

--- a/bin/compile
+++ b/bin/compile
@@ -96,7 +96,7 @@ fi
 
   status "Installing dependencies"
   # Make npm output to STDOUT instead of its default STDERR
-  npm install --userconfig $build_dir/.npmrc --production 2>&1 | indent
+  npm install --userconfig $build_dir/.npmrc 2>&1 | indent
 )
 
 # Persist goodies like node-version in the slug


### PR DESCRIPTION
This helps in keeping the local development devDependencies as is.
While in production env... it uses heroku configs to look up all the dependencies and install them then build the app and serve it.
